### PR TITLE
feat: Add link to full stargazers list

### DIFF
--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -44,7 +44,7 @@ Linux lover, cloud native builder and open source maintainer from Toulouse, Fran
 - [{{.Repo.Name}}]({{.Repo.URL}}) - {{.Repo.Description}} ({{humanize .StarredAt}})
 {{- end}}
 
-[View all stargazers](https://github.com/aslafy-z/aslafy-z/stargazers?direction=desc&sort=created)
+[View all stargazers ➡️](https://github.com/aslafy-z/aslafy-z/stargazers?direction=desc&sort=created)
 
 ## 📈 Stats
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -44,7 +44,7 @@ Linux lover, cloud native builder and open source maintainer from Toulouse, Fran
 - [{{.Repo.Name}}]({{.Repo.URL}}) - {{.Repo.Description}} ({{humanize .StarredAt}})
 {{- end}}
 
-[View all stargazers ➡️](https://github.com/aslafy-z/aslafy-z/stargazers?direction=desc&sort=created)
+[View all stargazers ->](https://github.com/aslafy-z/aslafy-z/stargazers?direction=desc&sort=created)
 
 ## 📈 Stats
 

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -44,6 +44,8 @@ Linux lover, cloud native builder and open source maintainer from Toulouse, Fran
 - [{{.Repo.Name}}]({{.Repo.URL}}) - {{.Repo.Description}} ({{humanize .StarredAt}})
 {{- end}}
 
+[View all stargazers](https://github.com/aslafy-z/aslafy-z/stargazers?direction=desc&sort=created)
+
 ## 📈 Stats
 
 <a href="#"><img height=200 align="center" src="https://github-readme-stats.vercel.app/api?username=aslafy-z&show_icons=true&count_private=true&hide_border=true&theme=transparent" alt="GitHub stats" /></a>

--- a/README.md.tmpl
+++ b/README.md.tmpl
@@ -44,7 +44,7 @@ Linux lover, cloud native builder and open source maintainer from Toulouse, Fran
 - [{{.Repo.Name}}]({{.Repo.URL}}) - {{.Repo.Description}} ({{humanize .StarredAt}})
 {{- end}}
 
-[View all stargazers ->](https://github.com/aslafy-z/aslafy-z/stargazers?direction=desc&sort=created)
+[View all stargazers →](https://github.com/aslafy-z/aslafy-z/stargazers?direction=desc&sort=created)
 
 ## 📈 Stats
 


### PR DESCRIPTION
Adds a link to the `README.md.tmpl` that points to the full list of stargazers for the profile repository, sorted by the latest first.

This allows visitors to easily navigate to see all users who have starred the profile.